### PR TITLE
Removed secrete keys from web.js

### DIFF
--- a/web.js
+++ b/web.js
@@ -1,6 +1,6 @@
 var express = require('express');
-var consumerKey = "wJTjmQgifUcO809yfuNkNQ";
-var consumerSecret = "yRLHDKYaVCpCIRY7n1BajRCuwCJ0XRqg4eULf28uk";
+var consumerKey = process.env.TWITTER_CONSUMER_KEY;
+var consumerSecret = process.env.TWITTER_CONSUMER_SECRET;
 var OAuth = require('oauth').OAuth
   , oauth = new OAuth(
       "https://api.twitter.com/oauth/request_token",


### PR DESCRIPTION
Per the recommendation on the twitter apps key interface: "Keep the "API secret" a secret. This key should never be human-readable in your application."

Maybe you already do something different, but its generally a bad idea to keep API keys in your source code.  Set those secret vars as ENV vars instead in your heroku or hosting environment. 

Also probably regenerate your keys, although I could be mistaken.
