### PR TITLE
UX tweaks for CSS/JS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A tool for indieweb live noting (aka live tweeting/live blogging).
 
 To try it go to http://www.noterlive.com
 
+For those wishing to properly display the available hovercard output on their websites, they should include the [javascript file](https://github.com/kevinmarks/noterlive/blob/master/web/hovercards.js) included in the repository in their root web folder and ensure that the displaying webpage includes `<script src="/hovercards.js"></script>`. One will also need to include appropriate CSS for displaying these cards, a possible sample can be found in `/resources/noterlive.css`.
+
 TO DO
 =====
 add a logout button for twitter

--- a/resources/noterlive.css
+++ b/resources/noterlive.css
@@ -1,0 +1,26 @@
+div .notercite {display:webkit-flex; display:flex;}
+
+.hovercard{
+	position: relative;
+}
+
+.hovercard .hidden-info{
+	opacity: 0;
+	max-height: 0;
+	max-width: 0;
+	overflow: hidden;
+	position: absolute;
+	top: 1.5em;
+	left: 0;
+	z-index:1;
+}
+
+.hovercard:hover .hidden-info{
+	border: #999 solid 1px;
+	box-shadow: 0 0 1em #999;
+	padding: 0.5em;
+	background: #fcfcfc;
+	opacity: 1;
+	max-height: 20em;
+	max-width: 20em;
+}

--- a/web/index.fr.html
+++ b/web/index.fr.html
@@ -118,7 +118,7 @@ function noteit() {
 }
 function getSpeakerHTML() {
     addHovercard = document.getElementById("hovercards").checked
-    html = "<div class='h-cite'>";
+    html = "<div class='notercite h-cite'>";
     if (addHovercard) {
         html = html+"<span class='hovercard'>";
     }

--- a/web/index.html
+++ b/web/index.html
@@ -119,7 +119,7 @@ function noteit() {
 }
 function getSpeakerHTML() {
     addHovercard = document.getElementById("hovercards").checked
-    html = "<div class='h-cite'>";
+    html = "<div class='notercite h-cite'>";
     if (addHovercard) {
         html = html+"<span class='hovercard'>";
     }


### PR DESCRIPTION
To help users cutting and pasting from noterlive output to their sites, I've added a CSS Class called notercite to a div so that it can be styled instead of the h-cite microformat semantic class.

Added a folder "resources" with some sample CSS for cutting and pasting into one's style.css file to help make supporting the hovercards "work". The sample CSS included uses the notercite class mentioned above.

Added a few lines in the readme about how to add CSS and JS to one's site to help the less technically minded.
